### PR TITLE
Added FIREWALL_AUTH_PORTAL_ADDRESS to ignore_objects

### DIFF
--- a/fortios/fortios_api_firewall_address.py
+++ b/fortios/fortios_api_firewall_address.py
@@ -96,6 +96,7 @@ system_global_api_args = {
     'default_ignore_params': [],
     "ignore_objects": [
         "Adobe Login",
+        "FIREWALL_AUTH_PORTAL_ADDRESS",
         "Gotomeeting",
         "SSLVPN_TUNNEL_ADDR1",
         "Windows update 2",


### PR DESCRIPTION
FIREWALL_AUTH_PORTAL_ADDRESS seems to be a static object in (at least) FortiGate 301E running FortiOS v5.6.4. Adding it to the current list of ignore_objects.